### PR TITLE
YML edited with new white spacing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ The DAOs include:
 - ScreeningRepository: DAO Repository utilizing JpaReposity & CrudRepositry interface methods used to fetch Screening id
 - SoftSkillViolationRepository: DAO Repository utilizing JpaReposity & CrudRepositry interface methods used to fetch Soft Skill Violation type
 - ViolationTypeRepository: DAO Repository utilizing JpaReposity & CrudRepositry interface methods used to fetch Violation type
+
+##YML
+The convention I found to be the most clear and readable for the YML files:
+- The document begins with the Spring declaration to begin with a uniform starting point, with no white space
+- All other main lines of the YML file begin with no white space 
+- From this intial main line, all following lines will get four additional white spaces
+- This process continues for as many additional lines as needed, with each getting an additional four white spaces
+- If any comments are added to the YML file then the # should be at the third white space
+- Any information for the comment should follow the line spacing listed above, so the # can be removed but the convention remains the same

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The DAOs include:
 - ViolationTypeRepository: DAO Repository utilizing JpaReposity & CrudRepositry interface methods used to fetch Violation type
 
 ##YML
-The convention I found to be the most clear and readable for the YML files:
+The convention for the YML files:
 - The document begins with the Spring declaration to begin with a uniform starting point, with no white space
 - All other main lines of the YML file begin with no white space 
 - From this intial main line, all following lines will get four additional white spaces

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,17 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Spring Cloud dependencies -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-config-client</artifactId>
+		</dependency>
 
 		<!-- H2 Database (In-Memory) -->
 		<dependency>
@@ -115,7 +126,7 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.8.0</version>
 		</dependency>
-		
+
 		<!-- JSON objects -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-server.port=8185

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,44 @@
+spring:
+   #Configure Test H2 Database
+    datasource:
+        driver-class-name: org.h2.Driver
+        platform: h2
+        url: jdbc:h2:mem:data;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+        username: sa
+        password:
+    jpa:
+        hibernate:
+            ddl-auto: update
+server:
+    port: 8185
+
+security:
+    basic:
+        enabled: false
+
+management:
+    security:
+        enabled: false
+
+
+   #  endpoints:
+   #    web:
+   #      cors:
+   #        allow-credentials: true
+   #        allowed-headers: *
+   #        allowed-methods: *
+   #        allowed-origins: http://ec2-35-183-67-26.ca-central-1.compute.amazonaws.com:4200/
+   #        max-age: 1800s
+
+info:
+    component: Screening Report Service
+
+eureka:
+    client:
+        service-url:
+            defaultZone: ${CALIBER_EUREKA_SERVER_URL}
+    instance:
+   #  hostName: ${CALIBER_INSTANCE_HOSTNAME:localhost}
+   #  statusPageUrl: http://${CALIBER_INSTANCE_HOSTNAME:localhost}:${server.port}/info
+   #  healthCheckUrl: http://${CALIBER_INSTANCE_HOSTNAME:localhost}:${server.port}/health
+

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,18 +1,20 @@
 spring:
-#Configure Test H2 Database
- datasource:
-   driver-class-name: org.h2.Driver
-   platform: h2
-   url: jdbc:h2:mem:data;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
-   username: sa
-   password:
- h2: 
-   console:
-      enabled: true
- jpa:
-   hibernate:
-     ddl-auto: update
+    application:
+        name: report-screening-service
+   #Configure Test H2 Database
+    datasource:
+        driver-class-name: org.h2.Driver
+        platform: h2
+        url: jdbc:h2:mem:data;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+        username: sa
+        password:
+    h2: 
+        console:
+            enabled: true
+    jpa:
+        hibernate:
+            ddl-auto: update
    #show-sql: true
- main:
-    allow-bean-definition-overriding: true
+    main:
+        allow-bean-definition-overriding: true
     


### PR DESCRIPTION
whitespacing structure I found to be the most clear and readable was as follows: every YML file begins with the Spring line, to make them all uniform; every main line starts without whitespace; then every additional line beneath the main line gets 4 whitespaces per line, this process continues for however many additional lines a given main line may need; if any comments are added to the document, the # begins at the 3rd whitespace, and the whitespace following the hashtag is as it should be if the # was not there (i.e. 4 white spaces for every line after the first)